### PR TITLE
Add ability cooldowns

### DIFF
--- a/Assets/Resources/PlayerPrefab1Aries.prefab
+++ b/Assets/Resources/PlayerPrefab1Aries.prefab
@@ -545,6 +545,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d8626fa831c95a441b94bd1631e4ed39, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  cooldownTime: 0.5
   hurtbox: {fileID: 4456246149412257730}
   toggleTime: 0.75
   forceVector: {x: 0, y: 50}
@@ -561,6 +562,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d8626fa831c95a441b94bd1631e4ed39, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  cooldownTime: 0.5
   hurtbox: {fileID: 2926048837673055937}
   toggleTime: 1
   forceVector: {x: 50, y: 15}

--- a/Assets/Scripts/Ability stuff/Ability.cs
+++ b/Assets/Scripts/Ability stuff/Ability.cs
@@ -4,5 +4,33 @@ using UnityEngine;
 
 public abstract class Ability : MonoBehaviour
 {
+    [SerializeField]
+    private float cooldownTime;
+    private float currentCooldown;
+
+    private void Start()
+    {
+        currentCooldown = 0f;
+    }
+    public void activate()
+    {
+        //If no cooldown, 
+        if (currentCooldown <= 0f)
+        {
+            currentCooldown = cooldownTime;
+            Use();
+        }
+    }
     public abstract void Use();
+
+    private void Update()
+    {
+        // Reduce cooldown
+        if (currentCooldown > 0f)
+        {
+            currentCooldown -= Time.deltaTime;
+        }
+
+        // Note: Some consideration to using couritines instead, currently no need to though
+    }
 }

--- a/Assets/Scripts/Photon Lobby Management/playerController.cs
+++ b/Assets/Scripts/Photon Lobby Management/playerController.cs
@@ -94,7 +94,7 @@ public class playerController : MonoBehaviour
             }
 
             fastFall = false;
-            ability1.Use();
+            ability1.activate();
         };
 
         abilityTwoAction.started += ability2Behavior =>
@@ -105,7 +105,7 @@ public class playerController : MonoBehaviour
             }
 
             fastFall = false;
-            ability2.Use();
+            ability2.activate();
         };
 
         lightAttackAction.started += lightAttackBehavior =>


### PR DESCRIPTION
Adds local cooldowns to abilities (default 0).
Note: Cooldowns only need to be local since we just need to sync the activation not when they can be activated.